### PR TITLE
Add platform specification for zookeeper and kafka services in docker…

### DIFF
--- a/kafka_example/docker-compose.yml
+++ b/kafka_example/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
+    platform: linux/amd64
     container_name: zookeeper
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
@@ -12,6 +13,7 @@ services:
 
   kafka:
     image: confluentinc/cp-kafka:7.5.0
+    platform: linux/amd64
     container_name: kafka
     depends_on:
       - zookeeper


### PR DESCRIPTION
This pull request includes changes to the `kafka_example/docker-compose.yml` file to ensure compatibility with the `linux/amd64` platform for the Zookeeper and Kafka services.

Platform compatibility updates:

* [`kafka_example/docker-compose.yml`](diffhunk://#diff-800c5e22fe2eb7448d320c2065dfd9af1446f35093e7d97e84d552bf01c13750R6): Added `platform: linux/amd64` to the Zookeeper service definition.
* [`kafka_example/docker-compose.yml`](diffhunk://#diff-800c5e22fe2eb7448d320c2065dfd9af1446f35093e7d97e84d552bf01c13750R16): Added `platform: linux/amd64` to the Kafka service definition.…-compose.yml